### PR TITLE
Rework vertical offset logic

### DIFF
--- a/examples/output.tex
+++ b/examples/output.tex
@@ -1,26 +1,28 @@
-\begin{figure} \centering \begin{tikzpicture}[xscale=2]
-\node (Label) at (0.3889823560155889, 0.7){\tiny{CD = 0.3338941360935335}}; % the label
-\draw[decorate,decoration={snake,amplitude=.4mm,segment length=1.5mm,post length=0mm},very thick, color = black] (0.3333333333333333,0.5) -- (0.44463137869784447,0.5);
-\foreach \x in {0.3333333333333333, 0.44463137869784447} \draw[thick,color = black] (\x, 0.4) -- (\x, 0.6);
- 
-\draw[gray, thick](0.3333333333333333,0) -- (2.0,0); 
-\foreach \x in {0.3333333333333333,0.6666666666666666,1.0,1.3333333333333333,1.6666666666666667,2.0} \draw (\x cm,1.5pt) -- (\x cm, -1.5pt);
-\node (Label) at (0.3333333333333333,0.2){\tiny{0}};
-\node (Label) at (0.6666666666666666,0.2){\tiny{1}};
-\node (Label) at (1.0,0.2){\tiny{2}};
-\node (Label) at (1.3333333333333333,0.2){\tiny{3}};
-\node (Label) at (1.6666666666666667,0.2){\tiny{4}};
-\node (Label) at (2.0,0.2){\tiny{5}};
+\begin{figure}
+\centering
+\begin{tikzpicture}[xscale=2]
+\node (Label) at (1.1669470680467668, 0.7){\tiny{CD = 0.33}}; % the label
+\draw[decorate,decoration={snake,amplitude=.4mm,segment length=1.5mm,post length=0mm},very thick, color = black] (1.0,0.5) -- (1.3338941360935335,0.5);
+\foreach \x in {1.0, 1.3338941360935335} \draw[thick,color = black] (\x, 0.4) -- (\x, 0.6);
+
+\draw[gray, thick](1.0,0) -- (6.0,0);
+\foreach \x in {1.0,2.0,3.0,4.0,5.0,6.0} \draw (\x cm,1.5pt) -- (\x cm, -1.5pt);
+\node (Label) at (1.0,0.2){\tiny{1}};
+\node (Label) at (2.0,0.2){\tiny{2}};
+\node (Label) at (3.0,0.2){\tiny{3}};
+\node (Label) at (4.0,0.2){\tiny{4}};
+\node (Label) at (5.0,0.2){\tiny{5}};
+\node (Label) at (6.0,0.2){\tiny{6}};
 \draw[decorate,decoration={snake,amplitude=.4mm,segment length=1.5mm,post length=0mm},very thick, color = black](3.0990196078431373,-0.25) -- (3.4098039215686273,-0.25);
 \draw[decorate,decoration={snake,amplitude=.4mm,segment length=1.5mm,post length=0mm},very thick, color = black](3.3098039215686277,-0.4) -- (3.6892156862745096,-0.4);
-\draw[decorate,decoration={snake,amplitude=.4mm,segment length=1.5mm,post length=0mm},very thick, color = black](4.147058823529412,-0.25) -- (4.432352941176471,-0.25);
+\draw[decorate,decoration={snake,amplitude=.4mm,segment length=1.5mm,post length=0mm},very thick, color = black](4.147058823529412,-0.55) -- (4.432352941176471,-0.55);
 \node (Point) at (2.272549019607843, 0){};\node (Label) at (0.5,-0.8500000000000001){\scriptsize{truth}}; \draw (Point) |- (Label);
 \node (Point) at (3.149019607843137, 0){};\node (Label) at (0.5,-1.1500000000000001){\scriptsize{rf}}; \draw (Point) |- (Label);
 \node (Point) at (3.3598039215686275, 0){};\node (Label) at (0.5,-1.4500000000000002){\scriptsize{xgb}}; \draw (Point) |- (Label);
-\node (Point) at (4.382352941176471, 0){};\node (Label) at (2.5,-0.8500000000000001){\scriptsize{majority}}; \draw (Point) |- (Label);
-\node (Point) at (4.197058823529412, 0){};\node (Label) at (2.5,-1.1500000000000001){\scriptsize{random}}; \draw (Point) |- (Label);
-\node (Point) at (3.6392156862745098, 0){};\node (Label) at (2.5,-1.4500000000000002){\scriptsize{svm}}; \draw (Point) |- (Label);
+\node (Point) at (4.382352941176471, 0){};\node (Label) at (6.5,-0.8500000000000001){\scriptsize{majority}}; \draw (Point) |- (Label);
+\node (Point) at (4.197058823529412, 0){};\node (Label) at (6.5,-1.1500000000000001){\scriptsize{random}}; \draw (Point) |- (Label);
+\node (Point) at (3.6392156862745098, 0){};\node (Label) at (6.5,-1.4500000000000002){\scriptsize{svm}}; \draw (Point) |- (Label);
 \end{tikzpicture}
-\caption{Nemenyi post hoc test}
+\caption{Nemenyi - input.csv}
 \label{fig:nemenyi}
 \end{figure}

--- a/utils/to_latex.py
+++ b/utils/to_latex.py
@@ -96,28 +96,18 @@ def writeTex(names, ranks, cd, output_file, caption, width=7):
 
     startY = -0.25
     deltaY = -0.15
-    yaxe = []
     x1 = 0
 
     for idx in range(len(segments)):
         seg = segments[idx]
         x1 = ranks_normalized[seg[0]] - 0.05
         x2 = ranks_normalized[seg[1]] + 0.05
-        if idx == 0:
-            yaxe.append(startY)
-        else:
-            y = startY
-            for prev in range(idx - 1, -1, -1):
-                ant = segments[prev]
-                previousX2 = ranks_normalized[ant[1]] + 0.5
-                if x1 - previousX2 <= 0.1 and yaxe[prev] == y:
-                    y = y + deltaY
-            yaxe.append(y)
+        y = startY + deltaY * idx
         text_script += "\\draw[{}]({},{}) -- ({},{});\n".format(
-            lineFormat, x1, yaxe[idx], x2, yaxe[idx]
+            lineFormat, x1, y, x2, y
         )
 
-    base = 0.25 + 0.2 * len(yaxe)
+    base = 0.25 + 0.2 * len(segments)
     x1 = 0.3
 
     for idx in range(int(len(names) / 2)):

--- a/utils/to_latex.py
+++ b/utils/to_latex.py
@@ -81,7 +81,7 @@ def writeTex(names, ranks, cd, output_file, caption, width=7):
         " -- (\\x, 0.6);\n \n".format(points[0], points[0] + normCd)
     )
 
-    text_script += "\\draw[gray, thick]({},0) -- ({},0); \n".format(
+    text_script += "\\draw[gray, thick]({},0) -- ({},0);\n".format(
         points[0], points[lastRank]
     )
 

--- a/utils/to_latex.py
+++ b/utils/to_latex.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def normalize_by_width(ranks, width):
-    return ([x * width / len(ranks) for x in ranks])
+    return [x * width / len(ranks) for x in ranks]
 
 
 def get_segments(ranks, cd):
@@ -12,7 +12,7 @@ def get_segments(ranks, cd):
     for i in range(len(ranks)):
         p2 = -1
         for j in range(i + 1, len(ranks)):
-            if (ranks[j] - ranks[i] < cd):
+            if ranks[j] - ranks[i] < cd:
                 p2 = j
         if p2 != -1:
             conected_points.append([i, p2])
@@ -49,38 +49,50 @@ def writeTex(names, ranks, cd, output_file, caption, width=7):
 
     ranks_normalized = normalize_by_width(ranks_sorted, width - 1)
 
-    lineFormat = ('decorate,decoration={snake,amplitude=.4mm,'
-                  'segment length=1.5mm,post length=0mm},'
-                  'very thick, color = black')
+    lineFormat = (
+        "decorate,decoration={snake,amplitude=.4mm,"
+        "segment length=1.5mm,post length=0mm},"
+        "very thick, color = black"
+    )
 
     points = range(1, len(ranks) + 1)
     points = normalize_by_width(points, width - 1)
 
-    normCd = cd * (width - 1.) / len(names)
+    normCd = cd * (width - 1.0) / len(names)
     lastRank = len(names) - 1
     margin = 0.5
     leftLabelPosition = margin
-    rightLabelPosition = margin + len(ranks) * (width - 1.) / len(ranks)
+    rightLabelPosition = margin + len(ranks) * (width - 1.0) / len(ranks)
 
     text_script = "\\begin{figure}\n\\centering\n\\begin{tikzpicture}[xscale=2]\n"
 
-    text_script = text_script + ('\\node (Label) at ({}, 0.7)'
-                                 '{{\\tiny{{CD = {:.2f}}}}}; % the label\n'.format(points[0] + normCd / 2, cd))
+    text_script += (
+        "\\node (Label) at ({}, 0.7)"
+        "{{\\tiny{{CD = {:.2f}}}}}; % the label\n".format(points[0] + normCd / 2, cd)
+    )
 
-    text_script = text_script + ('\\draw[{}] ({},0.5) -- ({},0.5);\n'.format(lineFormat, points[0], points[0] + normCd))
+    text_script += "\\draw[{}] ({},0.5) -- ({},0.5);\n".format(
+        lineFormat, points[0], points[0] + normCd
+    )
 
-    text_script = text_script + ('\\foreach \\x in {{{}, {}}} \\'
-                                 'draw[thick,color = black] (\\x, 0.4)'
-                                 ' -- (\\x, 0.6);\n \n'.format(points[0], points[0] + normCd))
+    text_script += (
+        "\\foreach \\x in {{{}, {}}} \\"
+        "draw[thick,color = black] (\\x, 0.4)"
+        " -- (\\x, 0.6);\n \n".format(points[0], points[0] + normCd)
+    )
 
-    text_script = text_script + ('\\draw[gray, thick]({},0) -- ({},0); \n'.format(points[0], points[lastRank]))
+    text_script += "\\draw[gray, thick]({},0) -- ({},0); \n".format(
+        points[0], points[lastRank]
+    )
 
-    point_names = ','.join(map(str, points))
-    text_script = text_script + ('\\foreach \\x in {{{}}} '
-                                 '\\draw (\\x cm,1.5pt) -- (\\x cm, -1.5pt);\n'.format(point_names))
+    point_names = ",".join(map(str, points))
+    text_script += (
+        "\\foreach \\x in {{{}}} "
+        "\\draw (\\x cm,1.5pt) -- (\\x cm, -1.5pt);\n".format(point_names)
+    )
 
     for idx, p in enumerate(points, 1):
-        text_script = text_script + "\\node (Label) at ({},0.2){{\\tiny{{{}}}}};\n".format(p, idx)
+        text_script += "\\node (Label) at ({},0.2){{\\tiny{{{}}}}};\n".format(p, idx)
 
     startY = -0.25
     deltaY = -0.15
@@ -101,29 +113,33 @@ def writeTex(names, ranks, cd, output_file, caption, width=7):
                 if x1 - previousX2 <= 0.1 and yaxe[prev] == y:
                     y = y + deltaY
             yaxe.append(y)
-        text_script = text_script + "\\draw[{}]({},{}) -- ({},{});\n".format(lineFormat, x1,
-                                                                             yaxe[idx], x2, yaxe[idx])
+        text_script += "\\draw[{}]({},{}) -- ({},{});\n".format(
+            lineFormat, x1, yaxe[idx], x2, yaxe[idx]
+        )
 
     base = 0.25 + 0.2 * len(yaxe)
     x1 = 0.3
 
     for idx in range(int(len(names) / 2)):
-        text_script = text_script + ('\\node (Point) at ({}, 0){{}};'
-                                     '\\node (Label) at ({},-{})'.format(ranks_normalized[idx],
-                                                                         leftLabelPosition, idx * x1 + base))
-        text_script = text_script + "{{\\scriptsize{{{}}}}}; \\draw (Point) |- (Label);\n".format(names_sorted[idx])
+        text_script += "\\node (Point) at ({}, 0){{}};" "\\node (Label) at ({},-{})".format(
+            ranks_normalized[idx], leftLabelPosition, idx * x1 + base
+        )
+        text_script += "{{\\scriptsize{{{}}}}}; \\draw (Point) |- (Label);\n".format(
+            names_sorted[idx]
+        )
 
     for idx in range(len(names) - 1, int((len(names) / 2)) - 1, -1):
-        text_script = text_script + ('\\node (Point) at ({}, 0){{}};'
-                                     '\\node (Label) at ({},-{})'.format(ranks_normalized[idx],
-                                                                         rightLabelPosition,
-                                                                         (len(names) - (idx + 1)) * x1 + base))
-        text_script = text_script + "{{\\scriptsize{{{}}}}}; \\draw (Point) |- (Label);\n".format(names_sorted[idx])
+        text_script += "\\node (Point) at ({}, 0){{}};" "\\node (Label) at ({},-{})".format(
+            ranks_normalized[idx], rightLabelPosition, (len(names) - (idx + 1)) * x1 + base
+        )
+        text_script += "{{\\scriptsize{{{}}}}}; \\draw (Point) |- (Label);\n".format(
+            names_sorted[idx]
+        )
 
-    text_script = text_script + "\\end{tikzpicture}\n"
-    text_script = text_script + f"\\caption{{{caption}}}\n"
-    text_script = text_script + "\\label{fig:nemenyi}\n"
-    text_script = text_script + "\\end{figure}\n"
+    text_script += "\\end{tikzpicture}\n"
+    text_script += f"\\caption{{{caption}}}\n"
+    text_script += "\\label{fig:nemenyi}\n"
+    text_script += "\\end{figure}\n"
 
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         f.write(text_script)


### PR DESCRIPTION
Hi @gabrielj12!

I'm having a bad time generating the chart with a bigger number of columns to be compared. The lines representing the cristical distance are getting the same `y` value. Thus, I removed the collision detection logic and simply added the `y` offset to each new line.

This worked for my use case, but I understand the previous behavior might be desired in smaller cases. I can try to fix the collision detection to make it work on both cases. Please let me know what you think!

P.S.: I also cleaned some parts of the code and run the Black code formatter, but separated it on a different commit to make it easy to review.

:bowtie: 